### PR TITLE
Update TestControllerPlayStation with Timer being ref-counted and protected_main

### DIFF
--- a/Tools/WebKitTestRunner/playstation/TestControllerPlayStation.cpp
+++ b/Tools/WebKitTestRunner/playstation/TestControllerPlayStation.cpp
@@ -33,7 +33,7 @@ namespace WTR {
 
 void TestController::notifyDone()
 {
-    RunLoop::main().stop();
+    RunLoop::protectedMain()->stop();
 }
 
 void TestController::platformInitialize(const Options&)
@@ -46,28 +46,24 @@ void TestController::platformDestroy()
 
 void TestController::platformRunUntil(bool& done, WTF::Seconds timeout)
 {
-    struct TimeoutTimer {
-        TimeoutTimer()
-            : timer(RunLoop::main(), this, &TimeoutTimer::fired)
-        { }
-
-        void fired()
+    bool timedOut = false;
+    class TimeoutTimer {
+    public:
+        TimeoutTimer(WTF::Seconds timeout, bool& timedOut)
+            : m_timer(RunLoop::main(), [&timedOut] {
+                timedOut = true;
+                RunLoop::protectedMain()->stop();
+            })
         {
-            timedOut = true;
-            RunLoop::main().stop();
+            if (timeout >= 0_s)
+                m_timer.startOneShot(timeout);
         }
+    private:
+        RunLoop::Timer m_timer;
+    } timeoutTimer(timeout, timedOut);
 
-        RunLoop::Timer timer;
-        bool timedOut { false };
-    } timeoutTimer;
-
-    if (timeout >= 0_s)
-        timeoutTimer.timer.startOneShot(timeout);
-
-    while (!done && !timeoutTimer.timedOut)
+    while (!done && !timedOut)
         RunLoop::main().run();
-
-    timeoutTimer.timer.stop();
 }
 
 void TestController::initializeInjectedBundlePath()


### PR DESCRIPTION
#### 7ae3ce9c105b7c09a383607a8d443b244cfd5d27
<pre>
Update TestControllerPlayStation with Timer being ref-counted and protected_main
<a href="https://bugs.webkit.org/show_bug.cgi?id=287838">https://bugs.webkit.org/show_bug.cgi?id=287838</a>

Reviewed by NOBODY (OOPS!).

<a href="https://github.com/WebKit/WebKit/commit/860c2ba52717fbcc180fa51464d1a92fc8d10acd">https://github.com/WebKit/WebKit/commit/860c2ba52717fbcc180fa51464d1a92fc8d10acd</a> and some patches
are missed on TestControllerPlayStation. This patch fixes based on them.

* Tools/WebKitTestRunner/playstation/TestControllerPlayStation.cpp:
(WTR::TestController::notifyDone):
(WTR::TestController::platformRunUntil):
</pre>